### PR TITLE
Represent policies with dictionaries for efficiency

### DIFF
--- a/algorithms/planner.py
+++ b/algorithms/planner.py
@@ -74,13 +74,8 @@ class Planner:
             V_track[i] = V
         if not converged:
             warnings.warn("Max iterations reached before convergence.  Check theta and n_iters.  ")
-        # Explanation of lambda:
-        # def pi(s):
-        #   policy = dict()
-        #   for state, action in enumerate(np.argmax(Q, axis=1)):
-        #       policy[state] = action
-        #   return policy[s]
-        pi = lambda s: {s:a for s, a in enumerate(np.argmax(Q, axis=1))}[s]
+
+        pi = {s:a for s, a in enumerate(np.argmax(Q, axis=1))}
         return V, V_track, pi
 
     @print_runtime
@@ -112,13 +107,8 @@ class Planner:
             Policy mapping states to actions.
         """
         random_actions = np.random.choice(tuple(self.P[0].keys()), len(self.P))
-        # Explanation of lambda:
-        # def pi(s):
-        #   policy = dict()
-        #   for state, action in enumerate(np.argmax(Q, axis=1)):
-        #       policy[state] = action
-        #   return policy[s]
-        pi = lambda s: {s: a for s, a in enumerate(random_actions)}[s]
+
+        pi = {s: a for s, a in enumerate(random_actions)}
         # initial V to give to `policy_evaluation` for the first time
         V = np.zeros(len(self.P), dtype=np.float64)
         V_track = np.zeros((n_iters, len(self.P)), dtype=np.float64)
@@ -126,11 +116,11 @@ class Planner:
         converged = False
         while i < n_iters-1 and not converged:
             i += 1
-            old_pi = {s: pi(s) for s in range(len(self.P))}
+            old_pi = pi
             V = self.policy_evaluation(pi, V, gamma, theta)
             V_track[i] = V
             pi = self.policy_improvement(V, gamma)
-            if old_pi == {s: pi(s) for s in range(len(self.P))}:
+            if old_pi == pi:
                 converged = True
         if not converged:
             warnings.warn("Max iterations reached before convergence.  Check n_iters.")
@@ -140,7 +130,7 @@ class Planner:
         while True:
             V = np.zeros(len(self.P), dtype=np.float64)
             for s in range(len(self.P)):
-                for prob, next_state, reward, done in self.P[s][pi(s)]:
+                for prob, next_state, reward, done in self.P[s][pi[s]]:
                     V[s] += prob * (reward + gamma * prev_V[next_state] * (not done))
             if np.max(np.abs(prev_V - V)) < theta:
                 break
@@ -153,11 +143,6 @@ class Planner:
             for a in range(len(self.P[s])):
                 for prob, next_state, reward, done in self.P[s][a]:
                     Q[s][a] += prob * (reward + gamma * V[next_state] * (not done))
-        # Explanation of lambda:
-        # def new_pi(s):
-        #   policy = dict()
-        #   for state, action in enumerate(np.argmax(Q, axis=1)):
-        #       policy[state] = action
-        #   return policy[s]
-        new_pi = lambda s: {s: a for s, a in enumerate(np.argmax(Q, axis=1))}[s]
+
+        new_pi = {s: a for s, a in enumerate(np.argmax(Q, axis=1))}
         return new_pi

--- a/algorithms/rl.py
+++ b/algorithms/rl.py
@@ -40,25 +40,25 @@ class RL:
         ----------------------------
         init_value {float}:
             Initial value of the quantity being decayed
-        
+
         min_value {float}:
             Minimum value init_value is allowed to decay to
-            
+
         decay_ratio {float}:
             The exponential factor exp(decay_ratio).
-            Updated decayed value is calculated as 
-        
+            Updated decayed value is calculated as
+
         max_steps {int}:
             Max iteration steps for decaying init_value
-        
+
         log_start {array-like}, default = -2:
             Starting value of the decay sequence.
             Default value starts it at 0.01
-        
+
         log_base {array-like}, default = 10:
             Base of the log space.
-        
-        
+
+
         Returns
         ----------------------------
         values {array-like}, shape(max_steps):
@@ -90,36 +90,36 @@ class RL:
         ----------------------------
         nS {int}:
             Number of states
-        
+
         nA {int}:
             Number of available actions
-            
+
         convert_state_obs {lambda}:
             The state conversion utilized in BlackJack ToyText problem.
             Returns three state tuple as one of the 280 converted states.
-        
+
         gamma {float}, default = 0.99:
             Discount factor
-        
+
         init_alpha {float}, default = 0.5:
             Learning rate
-        
+
         min_alpha {float}, default = 0.01:
             Minimum learning rate
-        
+
         alpha_decay_ratio {float}, default = 0.5:
             Decay schedule of learing rate for future iterations
-        
+
         init_epsilon {float}, default = 1.0:
             Initial epsilon value for epsilon greedy strategy.
             Chooses max(Q) over available actions with probability 1-epsilon.
-        
+
         min_epsilon {float}, default = 0.1:
             Minimum epsilon. Used to balance exploration in later stages.
-        
+
         epsilon_decay_ratio {float}, default = 0.9:
             Decay schedule of epsilon for future iterations
-            
+
         n_episodes {int}, default = 10000:
             Number of episodes for the agent
 
@@ -191,13 +191,8 @@ class RL:
             self.callbacks.on_episode_end(self)
 
         V = np.max(Q, axis=1)
-        # Explanation of lambda:
-        # def pi(s):
-        #   policy = dict()
-        #   for state, action in enumerate(np.argmax(Q, axis=1)):
-        #       policy[state] = action
-        #   return policy[s]
-        pi = lambda s: {s: a for s, a in enumerate(np.argmax(Q, axis=1))}[s]
+
+        pi = {s: a for s, a in enumerate(np.argmax(Q, axis=1))}
         return Q, V, pi, Q_track, pi_track
 
     @print_runtime
@@ -218,36 +213,36 @@ class RL:
         ----------------------------
         nS {int}:
             Number of states
-        
+
         nA {int}:
             Number of available actions
-            
+
         convert_state_obs {lambda}:
             The state conversion utilized in BlackJack ToyText problem.
             Returns three state tuple as one of the 280 converted states.
-        
+
         gamma {float}, default = 0.99:
             Discount factor
-        
+
         init_alpha {float}, default = 0.5:
             Learning rate
-        
+
         min_alpha {float}, default = 0.01:
             Minimum learning rate
-        
+
         alpha_decay_ratio {float}, default = 0.5:
             Decay schedule of learing rate for future iterations
-        
+
         init_epsilon {float}, default = 1.0:
             Initial epsilon value for epsilon greedy strategy.
             Chooses max(Q) over available actions with probability 1-epsilon.
-        
+
         min_epsilon {float}, default = 0.1:
             Minimum epsilon. Used to balance exploration in later stages.
-        
+
         epsilon_decay_ratio {float}, default = 0.9:
             Decay schedule of epsilon for future iterations
-            
+
         n_episodes {int}, default = 10000:
             Number of episodes for the agent
 
@@ -321,11 +316,6 @@ class RL:
             self.callbacks.on_episode_end(self)
 
         V = np.max(Q, axis=1)
-        # Explanation of lambda:
-        # def pi(s):
-        #   policy = dict()
-        #   for state, action in enumerate(np.argmax(Q, axis=1)):
-        #       policy[state] = action
-        #   return policy[s]
-        pi = lambda s: {s: a for s, a in enumerate(np.argmax(Q, axis=1))}[s]
+
+        pi = {s: a for s, a in enumerate(np.argmax(Q, axis=1))}
         return Q, V, pi, Q_track, pi_track

--- a/examples/plots.py
+++ b/examples/plots.py
@@ -56,14 +56,14 @@ if __name__ == "__main__":
     # VI/PI grid_world_policy_plot
     # V, V_track, pi = Planner(frozen_lake.env.P).value_iteration()
     # n_states = frozen_lake.env.observation_space.n
-    # new_pi = list(map(lambda x: pi(x), range(n_states)))
+    # new_pi = list(map(lambda x: pi[x], range(n_states)))
     # s = int(math.sqrt(n_states))
     # Plots.grid_world_policy_plot(np.array(new_pi), "Grid World Policy")
 
     # Q-learning grid_world_policy_plot
     # Q, V, pi, Q_track, pi_track = RL(frozen_lake.env).q_learning()
     # n_states = frozen_lake.env.observation_space.n
-    # new_pi = list(map(lambda x: pi(x), range(n_states)))
+    # new_pi = list(map(lambda x: pi[x], range(n_states)))
     # s = int(math.sqrt(n_states))
     # Plots.grid_world_policy_plot(np.array(new_pi), "Grid World Policy")
 

--- a/examples/test_env.py
+++ b/examples/test_env.py
@@ -28,21 +28,21 @@ class TestEnv:
 
         render {Boolean}:
             openAI human render mode
-        
+
         n_iters {int}, default = 10:
             Number of iterations to simulate the agent for
-        
+
         pi {lambda}:
             Policy used to calculate action value at a given state
-        
+
         user_input {Boolean}:
             Prompt for letting user decide which action to take at a given state
-        
+
         convert_state_obs {lambda}:
             The state conversion utilized in BlackJack ToyText problem.
             Returns three state tuple as one of the 280 converted states.
 
-        
+
         Returns
         ----------------------------
         test_scores {list}:
@@ -63,7 +63,7 @@ class TestEnv:
                 if user_input:
                     # get user input and suggest policy output
                     print("state is %i" % state)
-                    print("policy output is %i" % pi(state))
+                    print("policy output is %i" % pi[state])
                     while True:
                         action = input("Please select 0 - %i then hit enter:\n" % int(n_actions-1))
                         try:
@@ -76,7 +76,7 @@ class TestEnv:
                         else:
                             print("please enter a valid action, 0 - %i \n" % int(n_actions - 1))
                 else:
-                    action = pi(state)
+                    action = pi[state]
                 next_state, reward, terminated, truncated, info = env.step(action)
                 done = terminated or truncated
                 next_state = convert_state_obs(next_state, done)


### PR DESCRIPTION
The current implementation of policies with lambda functions causes policy iteration to be very slow, especially for large MDPs, because the full policy is generated repeatedly within the policy_evaluation function of the Planner class. This PR aims to solve this problem by converting the policies into dictionaries instead.