### PR TITLE
Returned the number of iterations needed to converge for VI and PI

### DIFF
--- a/bettermdptools/algorithms/planner.py
+++ b/bettermdptools/algorithms/planner.py
@@ -56,6 +56,8 @@ class Planner:
 
         pi {lambda}, input state value, output action value:
             Policy mapping states to actions.
+
+        n_iters {int}, number of iterations needed to converge
         """
         V = np.zeros(len(self.P), dtype=np.float64)
         V_track = np.zeros((n_iters, len(self.P)), dtype=np.float64)
@@ -76,7 +78,7 @@ class Planner:
             warnings.warn("Max iterations reached before convergence.  Check theta and n_iters.  ")
 
         pi = {s:a for s, a in enumerate(np.argmax(Q, axis=1))}
-        return V, V_track, pi
+        return V, V_track, pi, i
 
     @print_runtime
     def policy_iteration(self, gamma=1.0, n_iters=50, theta=1e-10):
@@ -105,6 +107,8 @@ class Planner:
 
         pi {lambda}, input state value, output action value:
             Policy mapping states to actions.
+
+        n_iters {int}, number of iterations needed to converge
         """
         random_actions = np.random.choice(tuple(self.P[0].keys()), len(self.P))
 
@@ -124,7 +128,7 @@ class Planner:
                 converged = True
         if not converged:
             warnings.warn("Max iterations reached before convergence.  Check n_iters.")
-        return V, V_track, pi
+        return V, V_track, pi, i
 
     def policy_evaluation(self, pi, prev_V, gamma=1.0, theta=1e-10):
         while True:

--- a/bettermdptools/algorithms/readme.md
+++ b/bettermdptools/algorithms/readme.md
@@ -53,6 +53,9 @@ V_track {numpy array}, shape(n_episodes, nS):
 pi {lambda}, input state value, output action value:
 	Policy mapping states to actions.  
 
+n_iters {int}
+	Number of iterations needed to converge
+
 ##### policy_iteration
 ```
 function bettermdptools.algorithms.planner.Planner.policy_iteration(self, 
@@ -81,6 +84,9 @@ V_track {numpy array}, shape(n_episodes, nS):
 	
 pi {lambda}, input state value, output action value:
 	Policy mapping states to actions.  
+
+n_iters {int}
+	Number of iterations needed to converge
 	
 ### RL 
 

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ from bettermdptools.utils.plots import Plots
 frozen_lake = gym.make('FrozenLake8x8-v1', render_mode=None)
 
 # run VI
-V, V_track, pi = Planner(frozen_lake.P).value_iteration()
+V, V_track, pi, n_iters = Planner(frozen_lake.P).value_iteration()
 
 #plot state values
 size=(8,8)


### PR DESCRIPTION
Returned the number of iterations needed to converge for VI and PI

It's nice to know how many iterations it took for the Value Iteration (VI) and
Policy Iteration (PI) algorithms to converge.  So I added this to the return values
of valid_iteration() and policy_iteration().

----------------------

(base) andy@Andy-Alienware-Aurora-R13:~/Git/bettermdptools$ cat test.py 
import gymnasium as gym
from bettermdptools.algorithms.planner import Planner
from bettermdptools.utils.plots import Plots

# make gym environment 
frozen_lake = gym.make('FrozenLake8x8-v1', render_mode=None)

# run VI
V, V_track, pi, n_iters = Planner(frozen_lake.P).value_iteration(n_iters=10000)
print(f'n_iters: {n_iters}')

# run PI
V, V_track, pi, n_iters = Planner(frozen_lake.P).policy_iteration(n_iters=100)
print(f'n_iters: {n_iters}')

(base) andy@Andy-Alienware-Aurora-R13:~/Git/bettermdptools$ python test.py 
runtime = 0.32 seconds
n_iters: 1437
runtime = 0.55 seconds
n_iters: 12
(base) andy@Andy-Alienware-Aurora-R13:~/Git/bettermdptools$ 

