### PR TITLE
Fix left side generated bins angles to be equal to right side ones

### DIFF
--- a/bettermdptools/envs/cartpole_model.py
+++ b/bettermdptools/envs/cartpole_model.py
@@ -157,7 +157,7 @@ class DiscretizedCartPole:
         left_bins = np.linspace(
             min_angle,
             -center_resolution,
-            num=int((center_resolution - min_angle) / outer_resolution) + 1,
+            num=int((-center_resolution - min_angle) / outer_resolution) + 1,
             endpoint=False,
         )
         right_bins = np.linspace(


### PR DESCRIPTION
The number of bins on the right side and left side are not equal since the equation on the left bin ends up being the sum of the min_angle and the center_resolution as the min_angle is already a negative value so the result is the sum not the difference which creates an imbalance between the number of bins on each side. 

Example
calling `DiscretizedCartPole(20, 20, 20, 0.1, 0.005)` returns a total of 105 values as follows
```
// left bin
[-2.09439510e-01 -2.07674357e-01 -2.05909203e-01 -2.04144050e-01
 -2.02378897e-01 -2.00613743e-01 -1.98848590e-01 -1.97083437e-01
 -1.95318283e-01 -1.93553130e-01 -1.91787976e-01 -1.90022823e-01
 -1.88257670e-01 -1.86492516e-01 -1.84727363e-01 -1.82962209e-01
 -1.81197056e-01 -1.79431903e-01 -1.77666749e-01 -1.75901596e-01
 -1.74136442e-01 -1.72371289e-01 -1.70606136e-01 -1.68840982e-01
 -1.67075829e-01 -1.65310675e-01 -1.63545522e-01 -1.61780369e-01
 -1.60015215e-01 -1.58250062e-01 -1.56484909e-01 -1.54719755e-01
 -1.52954602e-01 -1.51189448e-01 -1.49424295e-01 -1.47659142e-01
 -1.45893988e-01 -1.44128835e-01 -1.42363681e-01 -1.40598528e-01
 -1.38833375e-01 -1.37068221e-01 -1.35303068e-01 -1.33537914e-01
 -1.31772761e-01 -1.30007608e-01 -1.28242454e-01 -1.26477301e-01
 -1.24712147e-01 -1.22946994e-01 -1.21181841e-01 -1.19416687e-01
 -1.17651534e-01 -1.15886381e-01 -1.14121227e-01 -1.12356074e-01
 -1.10590920e-01 -1.08825767e-01 -1.07060614e-01 -1.05295460e-01
 -1.03530307e-01 -1.01765153e-01

// middle bin

 -1.00000000e-01 -9.00000000e-02
 -8.00000000e-02 -7.00000000e-02 -6.00000000e-02 -5.00000000e-02
 -4.00000000e-02 -3.00000000e-02 -2.00000000e-02 -1.00000000e-02
 -5.55111512e-17  1.00000000e-02  2.00000000e-02  3.00000000e-02
  4.00000000e-02  5.00000000e-02  6.00000000e-02  7.00000000e-02
  8.00000000e-02  9.00000000e-02  1.00000000e-01  

// right bin
1.00000000e-01
  1.05211405e-01  1.10422810e-01  1.15634216e-01  1.20845621e-01
  1.26057026e-01  1.31268431e-01  1.36479837e-01  1.41691242e-01
  1.46902647e-01  1.52114052e-01  1.57325458e-01  1.62536863e-01
  1.67748268e-01  1.72959673e-01  1.78171079e-01  1.83382484e-01
  1.88593889e-01  1.93805294e-01  1.99016700e-01  2.04228105e-01
  2.09439510e-01] 
```

After the fix, it returns a total of 65 with 22 on each side and 21 in the middle as the following

```
// left bin
[-2.09439510e-01 -2.04464987e-01 -1.99490464e-01 -1.94515941e-01
 -1.89541417e-01 -1.84566894e-01 -1.79592371e-01 -1.74617848e-01
 -1.69643325e-01 -1.64668802e-01 -1.59694278e-01 -1.54719755e-01
 -1.49745232e-01 -1.44770709e-01 -1.39796186e-01 -1.34821662e-01
 -1.29847139e-01 -1.24872616e-01 -1.19898093e-01 -1.14923570e-01
 -1.09949046e-01 -1.04974523e-01

// middle bin
-1.00000000e-01 -9.00000000e-02
 -8.00000000e-02 -7.00000000e-02 -6.00000000e-02 -5.00000000e-02
 -4.00000000e-02 -3.00000000e-02 -2.00000000e-02 -1.00000000e-02
 -5.55111512e-17  1.00000000e-02  2.00000000e-02  3.00000000e-02
  4.00000000e-02  5.00000000e-02  6.00000000e-02  7.00000000e-02
  8.00000000e-02  9.00000000e-02  1.00000000e-01 

// right bin
1.00000000e-01
  1.05211405e-01  1.10422810e-01  1.15634216e-01  1.20845621e-01
  1.26057026e-01  1.31268431e-01  1.36479837e-01  1.41691242e-01
  1.46902647e-01  1.52114052e-01  1.57325458e-01  1.62536863e-01
  1.67748268e-01  1.72959673e-01  1.78171079e-01  1.83382484e-01
  1.88593889e-01  1.93805294e-01  1.99016700e-01  2.04228105e-01
  2.09439510e-01]
```