### PR TITLE
Fix documentation and rename threshold_bins parameter

### DIFF
--- a/bettermdptools/envs/cartpole_model.py
+++ b/bettermdptools/envs/cartpole_model.py
@@ -16,18 +16,18 @@ class DiscretizedCartPole:
         position_bins,
         velocity_bins,
         angular_velocity_bins,
-        threshold_bins,
+        time_step,
         angular_center_resolution,
         angular_outer_resolution,
     ):
         """
-        Initializes the DiscretizedCartPole model.
+        Initializes the DiscretizedCartPole model. The model creates an array of initial transition probabilities.
 
         Parameters:
         - position_bins (int): Number of discrete bins for the cart's position.
         - velocity_bins (int): Number of discrete bins for the cart's velocity.
         - angular_velocity_bins (int): Number of discrete bins for the pole's angular velocity.
-        - threshold_bins (float): Step size for binned physics calculations.
+        - time_step (float): Controls how accurate the initial physics update calculation is. Used in calculating transition probabilities.
         - angular_center_resolution (float): The resolution of angle bins near the center (around zero).
         - angular_outer_resolution (float): The resolution of angle bins away from the center.
 
@@ -40,7 +40,7 @@ class DiscretizedCartPole:
         self.position_bins = position_bins
         self.velocity_bins = velocity_bins
         self.angular_velocity_bins = angular_velocity_bins
-        self.threshold_bins = threshold_bins
+        self.time_step = time_step
         self.action_space = 2  # Left or Right
 
         # Define the range for each variable
@@ -229,12 +229,12 @@ class DiscretizedCartPole:
         )[angular_velocity_idx]
 
         # Simulate physics here (simplified)
-        thresh = self.threshold_bins
+        delta_t = self.time_step
         force = 10 if action == 1 else -10
-        new_velocity = velocity + (force + np.sin(angle) * -10.0) * thresh
-        new_position = position + new_velocity * thresh
-        new_angular_velocity = angular_velocity + (3.0 * np.sin(angle) - force) * thresh
-        new_angle = angle + new_angular_velocity * thresh
+        new_velocity = velocity + (force + np.sin(angle) * -10.0) * delta_t
+        new_position = position + new_velocity * delta_t
+        new_angular_velocity = angular_velocity + (3.0 * np.sin(angle) - force) * delta_t
+        new_angle = angle + new_angular_velocity * delta_t
 
         new_position_idx = np.clip(
             np.digitize(

--- a/bettermdptools/envs/cartpole_wrapper.py
+++ b/bettermdptools/envs/cartpole_wrapper.py
@@ -55,7 +55,7 @@ class CartpoleWrapper(gym.Wrapper):
         position_bins=10,
         velocity_bins=10,
         angular_velocity_bins=10,
-        threshold_bins=0.5,
+        time_step=0.5,
         angular_center_resolution=0.1,
         angular_outer_resolution=0.5,
     ):
@@ -72,8 +72,8 @@ class CartpoleWrapper(gym.Wrapper):
             Number of discrete bins for the cart's velocity.
         angular_velocity_bins : int, optional
             Number of discrete bins for the pole's angular velocity.
-        threshold_bins : float, optional
-            Step size for binned physics calculations.
+        time_step : float, optional
+            Controls how accurate the initial physics update calculation is. Used in calculating transition probabilities.
         angular_center_resolution : float, optional
             The resolution of angle bins near the center (around zero).
         angular_outer_resolution : float, optional
@@ -83,7 +83,7 @@ class CartpoleWrapper(gym.Wrapper):
             position_bins=position_bins,
             velocity_bins=velocity_bins,
             angular_velocity_bins=angular_velocity_bins,
-            threshold_bins=threshold_bins,
+            time_step=time_step,
             angular_center_resolution=angular_center_resolution,
             angular_outer_resolution=angular_outer_resolution,
         )

--- a/bettermdptools/utils/plots.py
+++ b/bettermdptools/utils/plots.py
@@ -25,7 +25,7 @@ class Plots:
         if show:
             plt.show()
 
-    # modified from https://gymnasium.farama.org/tutorials/training_agents/FrozenLake_tuto/
+    # modified from https://gymnasium.farama.org/tutorials/training_agents/frozenlake_q_learning/#visualization
     @staticmethod
     def get_policy_map(pi, val_max, actions, map_size):
         """Map the best learned action to arrows."""
@@ -40,7 +40,7 @@ class Plots:
         val_max = val_max.reshape(map_size[0], map_size[1])
         return val_max, policy_map
 
-    # modified from https://gymnasium.farama.org/tutorials/training_agents/FrozenLake_tuto/
+    # modified from https://gymnasium.farama.org/tutorials/training_agents/frozenlake_q_learning/#visualization
     @staticmethod
     def plot_policy(val_max, directions, map_size, title, show=True):
         """Plot the policy learned."""


### PR DESCRIPTION
Fixes two confusing things I ran into while doing a project. 

Threshold_bins is really a time step for our cartpole model to calculate its initial transition probabilities. I changed it's name to time_step to better reflect this. Also some links were broken that are fixed now.