### PR TITLE
Use unwrapped env models to avoid warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ from bettermdptools.utils.plots import Plots
 frozen_lake = gym.make('FrozenLake8x8-v1', render_mode=None)
 
 # run VI
-V, V_track, pi = Planner(frozen_lake.P).value_iteration()
+# accessing P through env.unwrapped avoids Gymnasium's deprecated env.P warning
+V, V_track, pi = Planner(frozen_lake.unwrapped.P).value_iteration()
 
 #plot state values
 size=(8,8)

--- a/bettermdptools/utils/grid_search.py
+++ b/bettermdptools/utils/grid_search.py
@@ -81,6 +81,7 @@ class GridSearch:
         highest_avg_reward = -np.inf
         best_params = None
         rewards_and_params_results = []
+        env_model = env.unwrapped if hasattr(env, "unwrapped") else env
 
         for i in itertools.product(gamma, n_iters, theta):
             if verbose:
@@ -88,7 +89,7 @@ class GridSearch:
                     "running PI with gamma:", i[0], " n_iters:", i[1], " theta:", i[2]
                 )
 
-            V, V_track, pi = Planner(env.P).policy_iteration(
+            V, V_track, pi = Planner(env_model.P).policy_iteration(
                 gamma=i[0], n_iters=i[1], theta=i[2]
             )
             episode_rewards = TestEnv.test_env(env=env, n_iters=100, pi=pi)
@@ -109,6 +110,7 @@ class GridSearch:
         highest_avg_reward = -np.inf
         best_params = None
         rewards_and_params_results = []
+        env_model = env.unwrapped if hasattr(env, "unwrapped") else env
 
         for i in itertools.product(gamma, n_iters, theta):
             if verbose:
@@ -116,7 +118,7 @@ class GridSearch:
                     "running VI with gamma:", i[0], " n_iters:", i[1], " theta:", i[2]
                 )
 
-            V, V_track, pi = Planner(env.P).value_iteration(
+            V, V_track, pi = Planner(env_model.P).value_iteration(
                 gamma=i[0], n_iters=i[1], theta=i[2]
             )
             episode_rewards = TestEnv.test_env(env=env, n_iters=100, pi=pi)

--- a/compare_algorithms.py
+++ b/compare_algorithms.py
@@ -28,7 +28,8 @@ def run_value_iteration(env, n_iters=1000, vectorized=False, dtype=np.float64):
     Returns:
     tuple: Value function, value function track, and policy.
     """
-    planner = Planner(env.P)
+    env_model = env.unwrapped if hasattr(env, "unwrapped") else env
+    planner = Planner(env_model.P)
     if vectorized:
         V, V_track, pi = planner.value_iteration_vectorized(
             n_iters=n_iters, dtype=dtype

--- a/notebooks/blackjack.ipynb
+++ b/notebooks/blackjack.ipynb
@@ -64,7 +64,7 @@
     "blackjack = BlackjackWrapper(base_env)\n",
     "\n",
     "# run VI\n",
-    "V, V_track, pi = Planner(blackjack.P).value_iteration()\n",
+    "V, V_track, pi = Planner(blackjack.unwrapped.P).value_iteration()\n",
     "\n",
     "#test policy\n",
     "test_scores = TestEnv.test_env(env=blackjack, n_iters=100, render=False, pi=pi, user_input=False)\n",

--- a/notebooks/cartpole.ipynb
+++ b/notebooks/cartpole.ipynb
@@ -71,7 +71,7 @@
     "cartpole = CartpoleWrapper(base_env)\n",
     "\n",
     "# run VI\n",
-    "V, V_track, pi = Planner(cartpole.P).value_iteration()\n",
+    "V, V_track, pi = Planner(cartpole.unwrapped.P).value_iteration()\n",
     "\n",
     "#test policy\n",
     "test_scores = TestEnv.test_env(env=cartpole, n_iters=100, render=False, pi=pi, user_input=False)\n",

--- a/notebooks/frozen_lake.ipynb
+++ b/notebooks/frozen_lake.ipynb
@@ -61,7 +61,7 @@
     "frozen_lake = gym.make('FrozenLake8x8-v1', render_mode=None)\n",
     "\n",
     "# run VI\n",
-    "V, V_track, pi = Planner(frozen_lake.P).value_iteration()\n",
+    "V, V_track, pi = Planner(frozen_lake.unwrapped.P).value_iteration()\n",
     "\n",
     "#plot state values\n",
     "size=(8,8)\n",

--- a/notebooks/plots.ipynb
+++ b/notebooks/plots.ipynb
@@ -70,7 +70,7 @@
    ],
    "source": [
     "frozen_lake = gym.make('FrozenLake8x8-v1', render_mode=None)\n",
-    "V, V_track, pi = Planner(frozen_lake.P).value_iteration(n_iters=5000)\n",
+    "V, V_track, pi = Planner(frozen_lake.unwrapped.P).value_iteration(n_iters=5000)\n",
     "size=(8,8)\n",
     "Plots.values_heat_map(V, \"Frozen Lake\\nValue Iteration State Values\", size)"
    ]
@@ -133,7 +133,7 @@
     }
    ],
    "source": [
-    "fl_actions = {0: \"←\", 1: \"↓\", 2: \"→\", 3: \"↑\"}\n",
+    "fl_actions = {0: \"\u2190\", 1: \"\u2193\", 2: \"\u2192\", 3: \"\u2191\"}\n",
     "fl_map_size=(8,8)\n",
     "title=\"FL Mapped Policy\\nArrows represent best action\"\n",
     "val_max, policy_map = Plots.get_policy_map(pi, V, fl_actions, fl_map_size)\n",
@@ -178,7 +178,7 @@
     "blackjack = BlackjackWrapper(base_env)\n",
     "\n",
     "#run VI\n",
-    "V, V_track, pi = Planner(blackjack.P).value_iteration()\n",
+    "V, V_track, pi = Planner(blackjack.unwrapped.P).value_iteration()\n",
     "\n",
     "#create actions dictionary and set map size\n",
     "blackjack_actions = {0: \"S\", 1: \"H\"}\n",

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -1,0 +1,39 @@
+import warnings
+
+import gymnasium as gym
+from gymnasium import Wrapper
+
+from bettermdptools.utils.grid_search import GridSearch
+from compare_algorithms import run_value_iteration
+
+
+class WarnOnPWrapper(Wrapper):
+    """Wrapper that emits a warning when env.P is accessed."""
+
+    def __getattr__(self, item):
+        if item == "P":
+            warnings.warn("env.P deprecated in wrapper", UserWarning)
+        return super().__getattr__(item)
+
+
+def test_vi_grid_search_avoids_env_p_warning():
+    """Grid search should avoid accessing P"""
+    base_env = gym.make("FrozenLake8x8-v1", render_mode=None)
+    wrapped_env = WarnOnPWrapper(base_env)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", message=".*env\\.P deprecated in wrapper.*", category=UserWarning)
+        # unrelated warning for short runs
+        warnings.filterwarnings("ignore", message="Max iterations reached before convergence.*")
+
+        GridSearch.vi_grid_search(wrapped_env, gamma=[1.0], n_iters=[3], theta=[1e-3], verbose=False)
+
+
+def test_compare_algorithms_avoids_env_p_warning():
+    """Helper should avoid env.P on wrappers."""
+    base_env = gym.make("FrozenLake8x8-v1", render_mode=None)
+    wrapped_env = WarnOnPWrapper(base_env)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", message=".*env\\.P deprecated in wrapper.*", category=UserWarning)
+        warnings.filterwarnings("ignore", message="Max iterations reached before convergence.*")
+
+        run_value_iteration(wrapped_env, n_iters=3, vectorized=False)


### PR DESCRIPTION
  - Update planner utilities to pull transition matrices from env.unwrapped.P, eliminating deprecated env.P access in grid search and compare scripts.
  - Align README and all example notebooks to the same pattern so users don’t see Gymnasium deprecation warnings when running the samples.
  - Add a test to guard against direct env.P access.

Fixes #18